### PR TITLE
Convert Windows directory separators in upload paths

### DIFF
--- a/src/actions/remotelogic/deploylogic.go
+++ b/src/actions/remotelogic/deploylogic.go
@@ -74,6 +74,7 @@ func uploadFileToProvider(fsFuncs types.FSProviderFunctions, req UploadFileReque
 		dest = hashPrefix + "_" + dest
 	}
 	dest = filepath.Join(req.Dest, dest)
+	dest = filepath.ToSlash(dest)
 
 	log.Printf("Uploading to %s in %s (%s) [%d]\n", dest, req.Bucket, hashPrefix, req.CacheSeconds)
 


### PR DESCRIPTION
Should fix backslashes in remote paths mentioned in #13.

I was able to deploy to Amazon after this, although I've not tested with the other providers.