### PR TITLE
Don't install vet

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ It is possible to use a client-side router (where you have multiple request URLs
 #### For a Release (Cross Compiling)
 
 - Run `go get github.com/laher/goxc`
-- Run `go get code.google.com/p/go.tools/cmd/vet`
 - Run `./utils/xc.sh`
 
 The first run will take significantly longer than future runs.  The built files will be placed in the `./builds` directory.


### PR DESCRIPTION
Vet is a part of go tools since 2013(?) and you don't need to install it

I've tried to install it according to Building section and result is:
```
➜  Stout git:(master) go get code.google.com/p/go.tools/cmd/vet
package code.google.com/p/go.tools/cmd/vet: unrecognized import path "code.google.com/p/go.tools/cmd/vet" (parse https://code.google.com/p/go.tools/cmd/vet?go-get=1: no go-import meta tags (meta tag github.com/golang/go did not match import path code.google.com/p/go.tools/cmd/vet))
```